### PR TITLE
Replace View.propTypes with ViewPropTypes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-experimental-compat",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "NavigationExperimental as a package.",
   "main": "src/NavigationExperimental.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-experimental-compat",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "NavigationExperimental as a package.",
   "main": "src/NavigationExperimental.js",
   "scripts": {

--- a/src/NavigationHeader.js
+++ b/src/NavigationHeader.js
@@ -43,6 +43,7 @@ const {
   Platform,
   StyleSheet,
   View,
+  ViewPropTypes
 } = ReactNative;
 
 import type  {
@@ -115,7 +116,7 @@ class NavigationHeader extends React.PureComponent<DefaultProps, Props, any> {
     renderRightComponent: PropTypes.func,
     renderTitleComponent: PropTypes.func,
     statusBarHeight: PropTypes.number,
-    viewProps: PropTypes.shape(View.propTypes),
+    viewProps: PropTypes.shape(ViewPropTypes),
   };
 
   componentDidMount(): void {


### PR DESCRIPTION
`View.propTypes` is deprecated with newer versions of React Native. Replaced it with `ViewPropTypes` imported from `react-native`.

Bumped patch version.